### PR TITLE
Multi-Realm support, Edit Rank _POST fix and Temp Removal of non-released tools_interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ org.eclipse.php.core.projectOptions.prefs
 composer.phar
 phpunit.xml.dist
 contrib
+images/guildemblem/us_Velen_First_Regiment.png

--- a/acp/guild_module.php
+++ b/acp/guild_module.php
@@ -389,7 +389,9 @@ class guild_module extends Admin
             $newrank->RankId = $rank_id;
             $newrank->RankGuild = $oldrank->RankGuild;
             $newrank->RankName = $rank_name;
-            $newrank->RankHide = (isset($_POST['hide'][$rank_id])) ? 1 : 0;
+            $newrank->RankHide = ($this->request->is_set_post('hide') && isset($this->request->variable('hide', array(0 => ''), true)[$rank_id])) ? 1 : 0;
+
+            //$newrank->RankHide = (isset($_POST['hide'][$rank_id])) ? 1 : 0;
 
             $rank_prefix = $this->request->variable('prefix', array((int) $rank_id => ''), true);
             $newrank->RankPrefix = $rank_prefix[$rank_id];

--- a/migrations/release_2_0_0_m01_schema.php
+++ b/migrations/release_2_0_0_m01_schema.php
@@ -12,7 +12,7 @@ namespace bbdkp\bbguild\migrations;
 use phpbb\config\config;
 use phpbb\db\driver\driver_interface;
 use phpbb\db\migration\migration;
-use phpbb\db\tools\tools_interface;
+use phpbb\db\tools;
 
 /**
  * Migration stage 1: Initial schema
@@ -49,12 +49,12 @@ class release_2_0_0_m01_schema extends migration
      *
      * @param config $config
      * @param driver_interface $db
-     * @param tools_interface $db_tools
+     * @param tools $db_tools
      * @param string $phpbb_root_path
      * @param string $php_ext
      * @param string $table_prefix
      */
-    public function __construct(config $config, driver_interface $db, tools_interface $db_tools, $phpbb_root_path, $php_ext, $table_prefix)
+    public function __construct(config $config, driver_interface $db, tools $db_tools, $phpbb_root_path, $php_ext, $table_prefix)
     {
         parent::__construct($config, $db, $db_tools,  $phpbb_root_path, $php_ext, $table_prefix);
 

--- a/migrations/release_2_0_0_m01_schema.php
+++ b/migrations/release_2_0_0_m01_schema.php
@@ -233,7 +233,7 @@ class release_2_0_0_m01_schema extends migration
 
                     ),
                     'PRIMARY_KEY'  => 'player_id',
-                    'KEYS'         => array('UQ01'    => array('UNIQUE', array('player_guild_id', 'player_name'))),
+                    'KEYS'         => array('UQ01'    => array('UNIQUE', array('player_guild_id', 'player_name', 'player_realm'))),
                 ),
 
                 /*18*/


### PR DESCRIPTION
I have three changes in this pull.  It fixes multi-server realm guilds by updating the unique index.  It fixes where editing ranks directly accesses _POST resulting in a failure and it removes the as of yet unreleased tools_interface and replaces it with tools so that things will work against the current PHPBB 3.1.17 PL1 release.